### PR TITLE
Add global API response time logging middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "mongoose": "^8.0.3",
         "mongoose-aggregate-paginate-v2": "^1.0.7",
         "multer": "^1.4.5-lts.1",
+        "on-headers": "^1.0.2",
         "prettier": "^3.1.1"
       },
       "devDependencies": {
@@ -1532,6 +1533,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "on-headers": "^1.0.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.0.3",
     "mongoose-aggregate-paginate-v2": "^1.0.7",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
+import responseTimeLogger from './middleware/responseTime.middleware.js'
 
 const app = express();
 
@@ -9,6 +10,7 @@ app.use(express.json({ limit: "16kb" }))
 app.use(express.urlencoded({ extended: true, limit: "16kb" }))
 app.use(express.static("public"))
 app.use(cookieParser())
+app.use(responseTimeLogger)
 
 
 

--- a/src/middleware/responseTime.middleware.js
+++ b/src/middleware/responseTime.middleware.js
@@ -1,0 +1,25 @@
+import onHeaders from 'on-headers'
+
+// Middleware to log response time for each request
+export function responseTimeLogger(req, res, next) {
+  const startHrTime = process.hrtime.bigint();
+
+  onHeaders(res, () => {
+    const endHrTime = process.hrtime.bigint();
+    const durationNs = endHrTime - startHrTime;
+    const durationMs = Number(durationNs) / 1_000_000; // convert to ms
+
+    const method = req.method;
+    const path = req.originalUrl || req.url;
+    // Round to 2 decimals for readability
+    const roundedMs = Math.round(durationMs * 100) / 100;
+
+    // Basic log to stdout; replace with a logger if present
+    console.log(`[RT] ${method} ${path} - ${roundedMs} ms`);
+  });
+
+  next();
+}
+
+export default responseTimeLogger;
+


### PR DESCRIPTION
### Summary
- Adds a lightweight middleware to log response times for all API endpoints
- Logs HTTP method, path, and duration in milliseconds
- Helps identify slow endpoints during development and monitoring

### Changes
- Added `src/middleware/responseTime.middleware.js`
- Registered middleware in `src/app.js` before routes
- Added dependency `on-headers` to `package.json`

### Implementation Details
- Uses `process.hrtime.bigint()` for high-resolution timing
- Hooks into response headers with `on-headers` to compute total request duration
- Logs to stdout in the format:
  - `[RT] GET /api/v1/videos - 12.34 ms`

### Example Log Output
```
[RT] POST /api/v1/users/login - 48.71 ms
[RT] GET /api/v1/videos?limit=10 - 12.34 ms
```

### How to Test
1. Start the server.
2. Hit any endpoint (e.g., `GET /api/v1/videos`).
3. Verify a log line is printed with method, path, and response time.

### Motivation
- No prior response time tracking made identifying slow endpoints difficult.
- Provides immediate visibility into endpoint performance with minimal overhead.

### Notes
- Current output goes to stdout; can be swapped for a structured logger later.
- Middleware is intentionally kept simple and non-intrusive.

### Checklist
- [x] Middleware added and imported globally
- [x] Dependency installed (`on-headers`)
- [x] Verified logs appear for various endpoints
- [x] No linter errors

### Related Issue
Closes #16 